### PR TITLE
Use InvariantCulture to convert double representation of ModifiedDate to string

### DIFF
--- a/PushbulletSharp.Tests/PushTests.cs
+++ b/PushbulletSharp.Tests/PushTests.cs
@@ -262,7 +262,7 @@ namespace PushbulletSharp.Tests
             {
                 PushResponseFilter filter = new PushResponseFilter()
                 {
-                    ModifiedDate = new DateTime(2015, 8, 14),
+                    ModifiedDate = new DateTime(2015,10,15,20,10,40,32),
                     Active = true
                 };
                 var results = Client.GetPushes(filter);

--- a/PushbulletSharp/PushbulletClient.cs
+++ b/PushbulletSharp/PushbulletClient.cs
@@ -774,7 +774,8 @@ namespace PushbulletSharp
                 {
                     if (filter.ModifiedDate != null)
                     {
-                        string modifiedDateQueryString = string.Format("modified_after={0}", filter.ModifiedDate.DateTimeToUnixTime());
+                        string modifiedDate = filter.ModifiedDate.DateTimeToUnixTime().ToString(System.Globalization.CultureInfo.InvariantCulture);
+                        string modifiedDateQueryString = string.Format("modified_after={0}", modifiedDate);
                         queryStringList.Add(modifiedDateQueryString);
                     }
 


### PR DESCRIPTION
Hi,

I live in Belgium and I had a bug when I use the `getPushes` method.
I always got the following error: `{"Assert.Fail failed. 400 Bad Request - Usually this results from missing a required parameter."}`

After some debugging I found that the Pushbullet API does not work with comma characters in the `modified_after` field. Since this field can be a double value, and in Belgium the default conversion of a double to a string contains a comma, I changed the double to string conversion code in the getPushes method.

Reproduction of the error:
1. Change your laptop's region setting to 'Dutch (Belgium)'
2. Use a non integer DateTime value (as I added in the unit test)
3. Execute the `GetPushesAllSince` unit test
4. You will get the error above

Done to fix the issue:
Changed the Culture of the conversion to InvariantCulture.

Kind regards,
Dries
