### PR TITLE
Fixed bug regarding getting pushes with Modified since parameter

### DIFF
--- a/PushbulletSharp.Tests/PushTests.cs
+++ b/PushbulletSharp.Tests/PushTests.cs
@@ -392,8 +392,8 @@ namespace PushbulletSharp.Tests
                 };
                 response = Client.PushNote(request);
 
-                // Get pushes since first one.
-                results = Client.GetPushes(new PushResponseFilter() { ModifiedDate = lastModified });
+                // Get pushes since first one, + one millisecond because otherwise we can get back our previous received push...s
+                results = Client.GetPushes(new PushResponseFilter() { ModifiedDate = lastModified.AddMilliseconds(1)});
                 //should have only the second push
                 Assert.AreEqual(1, results.Pushes.Count);
                 Assert.AreEqual(secondBody, results.Pushes[0].Body);

--- a/PushbulletSharp.Tests/PushTests.cs
+++ b/PushbulletSharp.Tests/PushTests.cs
@@ -392,7 +392,7 @@ namespace PushbulletSharp.Tests
                 };
                 response = Client.PushNote(request);
 
-                // Get pushes since first one, + one millisecond because otherwise we can get back our previous received push...s
+                // Get pushes since first one, + one millisecond because otherwise we can get back our previous received push...
                 results = Client.GetPushes(new PushResponseFilter() { ModifiedDate = lastModified.AddMilliseconds(1)});
                 //should have only the second push
                 Assert.AreEqual(1, results.Pushes.Count);

--- a/PushbulletSharp.Tests/PushTests.cs
+++ b/PushbulletSharp.Tests/PushTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using PushbulletSharp;
+using System.Threading;
 
 namespace PushbulletSharp.Tests
 {
@@ -356,6 +357,46 @@ namespace PushbulletSharp.Tests
                 };
 
                 var results = Client.GetPushes(filter);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
+
+        [TestMethod]
+        public void GetPushesSinceLastPush()
+        {
+            try
+            {
+                // Push a first note
+                PushNoteRequest request = new PushNoteRequest()
+                {
+                    Title = "Push one",
+                    Body = "This is the first message."
+                };
+                var response = Client.PushNote(request);
+
+                // Get modified date of last push
+                var results = Client.GetPushes(new PushResponseFilter() { Limit = 1 });
+                var lastModified = results.Pushes[0].Modified;
+
+                Thread.Sleep(1000);
+
+                // Push a second note
+                var secondBody = "This is the second message.";
+                request = new PushNoteRequest()
+                {
+                    Title = "Push two",
+                    Body = secondBody
+                };
+                response = Client.PushNote(request);
+
+                // Get pushes since first one.
+                results = Client.GetPushes(new PushResponseFilter() { ModifiedDate = lastModified });
+                //should have only the second push
+                Assert.AreEqual(1, results.Pushes.Count);
+                Assert.AreEqual(secondBody, results.Pushes[0].Body);
             }
             catch (Exception ex)
             {

--- a/PushbulletSharp/Extensions/PushbulletSharpExtensions.cs
+++ b/PushbulletSharp/Extensions/PushbulletSharpExtensions.cs
@@ -56,17 +56,19 @@ namespace PushbulletSharp
         }
 
         /// <summary>
-        /// Dates the time to unix time.
+        /// Dates the time to unix time (at UTC timezone).
         /// </summary>
         /// <param name="dateTime">The date time.</param>
         /// <returns></returns>
         public static double DateTimeToUnixTime(this DateTime dateTime)
         {
-            return (dateTime - new DateTime(1970, 1, 1).ToLocalTime()).TotalSeconds;
+            var epochTime = new DateTime(1970, 1, 1);
+            var utcTime = TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Utc);
+            return (utcTime - epochTime).TotalSeconds;
         }
 
         /// <summary>
-        /// Dates the time to unix time.
+        /// Dates the time to unix time (at UTC timezone).
         /// </summary>
         /// <param name="dateTime">The date time.</param>
         /// <returns></returns>
@@ -75,11 +77,11 @@ namespace PushbulletSharp
             if(dateTime != null)
             {
                 DateTime nonNullDateTime = dateTime ?? DateTime.Now;
-                return (nonNullDateTime - new DateTime(1970, 1, 1).ToLocalTime()).TotalSeconds;
+                return nonNullDateTime.DateTimeToUnixTime();
             }
             else
             {
-                return (DateTime.Now - new DateTime(1970, 1, 1).ToLocalTime()).TotalSeconds;
+                return DateTime.Now.DateTimeToUnixTime();
             }
         }
 


### PR DESCRIPTION
Hi,

I fixed a bug regarding getting pushes using the Modified attribute. In the old code, the modified unix time string was not in the correct timezone. The modified attribute for the request needs to be in UTC time. In the old code, this is not always the case.

I also added a test that will normally fail with the old code, and that will succeed in the fixed code.
The test pushes a note, waits for some time, then pushes a new note. After that, we get all pushes that are modified since we pushed the first note.

Kind regards,
Dries
