### PR TITLE
Added service method to create devices and switched core project to .NET Standard 2.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,7 @@ jobs:
       uses: brandedoutcast/publish-nuget@v2.5.5
       with:
         # Filepath of the project to be packaged, relative to root of repository
-        PROJECT_FILE_PATH: "PushbulletSharp"
+        PROJECT_FILE_PATH: "PushbulletSharp/PushbulletSharp.csproj"
         # NuGet package id, used for version detection & defaults to project name
         PACKAGE_NAME: "PushbulletSharp"
         # API key to authenticate with NuGet server

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,27 @@
+name: .NET
+
+on:
+  push:
+    branches: [ Integration ]
+  pull_request:
+    branches: [ Integration ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Publish NuGet
+      # You may pin to the exact commit or the version.
+      # uses: brandedoutcast/publish-nuget@c12b8546b67672ee38ac87bea491ac94a587f7cc
+      uses: brandedoutcast/publish-nuget@v2.5.5
+      with:
+        # Filepath of the project to be packaged, relative to root of repository
+        PROJECT_FILE_PATH: "PushbulletSharp"
+        # NuGet package id, used for version detection & defaults to project name
+        PACKAGE_NAME: "PushbulletSharp"
+        # API key to authenticate with NuGet server
+        NUGET_KEY: "17ded98493732c649f2474e78890ff567767b26b"
+        # NuGet server uri hosting the packages, defaults to https://api.nuget.org
+        NUGET_SOURCE: "https://nuget.pkg.github.com/kekonn/index.json"

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ PushbulletSharp.PrivateWebSocketConsole/
 PushbulletSharpPrivate.sln
 .vs/
 /.vs
+.idea/**

--- a/PushbulletSharp.Tests/PushbulletSharp.Tests.csproj
+++ b/PushbulletSharp.Tests/PushbulletSharp.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PushbulletSharp.Tests</RootNamespace>
     <AssemblyName>PushbulletSharp.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/PushbulletSharp.WebSocketConsole/App.config
+++ b/PushbulletSharp.WebSocketConsole/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/PushbulletSharp.WebSocketConsole/PushbulletSharp.WebSocketConsole.csproj
+++ b/PushbulletSharp.WebSocketConsole/PushbulletSharp.WebSocketConsole.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PushbulletSharp.WebSocketConsole</RootNamespace>
     <AssemblyName>PushbulletSharp.WebSocketConsole</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/PushbulletSharp/Encryption/EncryptionUtility.cs
+++ b/PushbulletSharp/Encryption/EncryptionUtility.cs
@@ -67,7 +67,7 @@ namespace PushbulletSharp.Encryption
             var nonce = new byte[NonceBitSize / 8];
             Random.NextBytes(nonce, 0, nonce.Length);
 
-            var cipher = new GcmBlockCipher(new AesFastEngine());
+            var cipher = new GcmBlockCipher(new AesEngine());
             var parameters = new AeadParameters(new KeyParameter(keyBytes), TagBitSize, nonce);
             cipher.Init(true, parameters);
 
@@ -142,7 +142,7 @@ namespace PushbulletSharp.Encryption
                     // Get the Nonce (IV)
                     var nonce = cipherReader.ReadBytes(NonceBitSize / 8);
 
-                    var cipher = new GcmBlockCipher(new AesFastEngine());
+                    var cipher = new GcmBlockCipher(new AesEngine());
                     var parameters = new AeadParameters(new KeyParameter(keyBytes), TagBitSize, nonce);
                     cipher.Init(false, parameters);
 

--- a/PushbulletSharp/Models/Requests/CreateDeviceRequest.cs
+++ b/PushbulletSharp/Models/Requests/CreateDeviceRequest.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace PushbulletSharp.Models.Requests
+{
+    [DataContract]
+    public class CreateDeviceRequest
+    {
+        /// <summary>
+        /// The device's nickname
+        /// </summary>
+        /// <remarks>
+        /// This is the name that's usualy visible in the UI
+        /// </remarks>
+        [DataMember(Name = "nickname")]
+        public string Nickname { get; set; }
+
+        [DataMember(Name = "model")]
+        public string Model { get; set; }
+
+        [DataMember(Name = "manufacturer")]
+        public string  Manufacturer { get; set; }
+
+        [DataMember(Name = "app_version")]
+        public int AppVersion { get; set; }
+    }
+}

--- a/PushbulletSharp/PushbulletClient.cs
+++ b/PushbulletSharp/PushbulletClient.cs
@@ -633,6 +633,27 @@ namespace PushbulletSharp
 
         #endregion Channels Methods
 
+        #region Devices
+
+        /// <summary>
+        /// Create a new device
+        /// </summary>
+        /// <param name="device"></param>
+        /// <returns>the device object after processing by Pushbullet</returns>
+        public Device CreateDevice(Device device)
+        {
+            try
+            {
+                var result = PostRequest<Device>(string.Concat(PushbulletConstants.BaseUrl, PushbulletConstants.DevicesUrls.Me), device);
+                return result;
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+
+        #endregion
 
         #region Push Methods
 

--- a/PushbulletSharp/PushbulletSharp.csproj
+++ b/PushbulletSharp/PushbulletSharp.csproj
@@ -11,10 +11,9 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFramework>netstandard20</TargetFramework>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   

--- a/PushbulletSharp/PushbulletSharp.csproj
+++ b/PushbulletSharp/PushbulletSharp.csproj
@@ -1,8 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{459FDFF0-D68E-49AE-961F-0912916B78AB}</ProjectGuid>
@@ -13,8 +11,10 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFramework>netstandard20</TargetFramework>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,84 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Constants\PushbulletConstants.cs" />
-    <Compile Include="Encryption\EncryptionUtility.cs" />
-    <Compile Include="Extensions\PushbulletSharpExtensions.cs" />
-    <Compile Include="Filters\PushResponseFilter.cs" />
-    <Compile Include="Models\Requests\BasicUpdateChatRequest.cs" />
-    <Compile Include="Models\Requests\ChannelSubscriptionRequest.cs" />
-    <Compile Include="Models\Requests\CreateChatRequest.cs" />
-    <Compile Include="Models\Requests\CreateContactRequest.cs" />
-    <Compile Include="Models\Requests\DeleteChatRequest.cs" />
-    <Compile Include="Models\Requests\DeleteContactRequest.cs" />
-    <Compile Include="Models\Requests\Ephemerals\EncryptedEphemeralMessage.cs" />
-    <Compile Include="Models\Requests\Ephemerals\EncryptedEphemeralRequest.cs" />
-    <Compile Include="Models\Requests\Ephemerals\EphemeralRequest.cs" />
-    <Compile Include="Models\Requests\Ephemerals\EphemeralRequestBase.cs" />
-    <Compile Include="Models\IEphemeral.cs" />
-    <Compile Include="Models\Requests\Ephemerals\DismissalEphemeral.cs" />
-    <Compile Include="Models\Requests\Ephemerals\NotificationEphemeral.cs" />
-    <Compile Include="Models\Requests\Ephemerals\SMSEphemeral.cs" />
-    <Compile Include="Models\Requests\Ephemerals\StringEphemeralRequest.cs" />
-    <Compile Include="Models\Requests\Ephemerals\UniversalCopyPasteEphemeral.cs" />
-    <Compile Include="Models\Requests\OAuthTokenRequest.cs" />
-    <Compile Include="Models\Requests\PushFileRequest.cs" />
-    <Compile Include="Models\Requests\PushLinkRequest.cs" />
-    <Compile Include="Models\Requests\PushNoteRequest.cs" />
-    <Compile Include="Models\Requests\PushRequestBase.cs" />
-    <Compile Include="Models\Requests\UpdateChatRequest.cs" />
-    <Compile Include="Models\Requests\UpdateContactRequest.cs" />
-    <Compile Include="Models\Responses\BasicChat.cs" />
-    <Compile Include="Models\Responses\BasicChatResponse.cs" />
-    <Compile Include="Models\Responses\BasicPushResponse.cs" />
-    <Compile Include="Models\Responses\BasicPushResponseContainer.cs" />
-    <Compile Include="Models\Responses\BasicSubscription.cs" />
-    <Compile Include="Models\Responses\BasicUserSubscriptions.cs" />
-    <Compile Include="Models\Responses\Channel.cs" />
-    <Compile Include="Models\Responses\Chat.cs" />
-    <Compile Include="Models\Responses\ChatContact.cs" />
-    <Compile Include="Models\Responses\Ephemerals\DismissalEphemeral.cs" />
-    <Compile Include="Models\Responses\Ephemerals\NotificationEphemeral.cs" />
-    <Compile Include="Models\Responses\Ephemerals\SMSEphemeral.cs" />
-    <Compile Include="Models\Responses\Ephemerals\UniversalCopyPasteEphemeral.cs" />
-    <Compile Include="Models\Responses\UserChats.cs" />
-    <Compile Include="Models\Responses\Contact.cs" />
-    <Compile Include="Models\Responses\Device.cs" />
-    <Compile Include="Models\Responses\FileUploadResponse.cs" />
-    <Compile Include="Models\Responses\GoogleUserInfo.cs" />
-    <Compile Include="Models\Responses\OAuthTokenResponse.cs" />
-    <Compile Include="Models\Responses\PushResponse.cs" />
-    <Compile Include="Models\Responses\PushResponseContainer.cs" />
-    <Compile Include="Models\Responses\Subscription.cs" />
-    <Compile Include="Models\Responses\User.cs" />
-    <Compile Include="Models\Responses\UserContacts.cs" />
-    <Compile Include="Models\Responses\UserDevices.cs" />
-    <Compile Include="Models\Responses\UserPreferences.cs" />
-    <Compile Include="Models\Responses\UserSubscriptions.cs" />
-    <Compile Include="Models\Responses\WebSocket\GenericPushTypeResponse.cs" />
-    <Compile Include="Models\Responses\WebSocket\WebSocketPushResponse.cs" />
-    <Compile Include="Models\Responses\WebSocket\WebSocketResponse.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="PushbulletClient.cs" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="BouncyCastle">
-      <HintPath>..\ExternalLibraries\BouncyCastle.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  
 </Project>

--- a/PushbulletSharp/packages.config
+++ b/PushbulletSharp/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable45-net45+win8+wpa81" />
-</packages>


### PR DESCRIPTION
The tests and Webconsole now compile against 4.7.2 (because I saw no need to convert these further).

The core library compiles against .NET Standard 2.0, which makes it interchangeable with .NET Core and regular .NET.

I use Rider so I had to update the .gitignore. I also fixed a warning about `AesFastEngine` begin deprecated.

There's just one issue, it won't stop generating an AssemblyInfo.cs file.